### PR TITLE
Change primary modal view action shortcut to cmd+return

### DIFF
--- a/GitUpKit/Views/Base.lproj/GIAdvancedCommitViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GIAdvancedCommitViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -225,7 +225,7 @@
                                         <string key="keyEquivalent" base64-UTF8="YES">
 DQ
 </string>
-                                        <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+                                        <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                         <connections>
                                             <action selector="commit:" target="-2" id="TeY-Mz-e1l"/>
                                         </connections>

--- a/GitUpKit/Views/Base.lproj/GICommitRewriterViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GICommitRewriterViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,19 +20,19 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <view translatesAutoresizingMaskIntoConstraints="NO" id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
+        <view id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <customView id="GrA-cS-Ts1">
+                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GrA-cS-Ts1">
                     <rect key="frame" x="0.0" y="470" width="1000" height="30"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <subviews>
-                        <box verticalHuggingPriority="750" boxType="separator" id="e23-jK-FRM">
+                        <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="e23-jK-FRM">
                             <rect key="frame" x="0.0" y="-2" width="1000" height="5"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                         </box>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="r86-wZ-wly">
+                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r86-wZ-wly">
                             <rect key="frame" x="13" y="8" width="122" height="16"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Rewriting Commit:" id="e11-6O-HXn">
@@ -41,34 +41,34 @@
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="hZw-Mr-R8r">
+                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hZw-Mr-R8r">
                             <rect key="frame" x="135" y="8" width="847" height="16"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;TITLE&gt;" id="rrE-b8-3j3">
-                                <font key="font" metaFont="controlContent"/>
+                                <font key="font" metaFont="cellTitle"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
                     </subviews>
                 </customView>
-                <splitView dividerStyle="thin" vertical="YES" id="ggX-gG-WJV" customClass="GIDualSplitView">
+                <splitView fixedFrame="YES" dividerStyle="thin" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ggX-gG-WJV" customClass="GIDualSplitView">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="470"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>
-                        <customView id="ac4-Pc-4Ig">
+                        <customView fixedFrame="YES" id="ac4-Pc-4Ig">
                             <rect key="frame" x="0.0" y="0.0" width="300" height="470"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
-                                <box verticalHuggingPriority="750" boxType="separator" id="ZBF-ni-AKe">
+                                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ZBF-ni-AKe">
                                     <rect key="frame" x="0.0" y="43" width="300" height="5"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 </box>
-                                <customView id="OjA-hK-WAP">
+                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OjA-hK-WAP">
                                     <rect key="frame" x="0.0" y="46" width="300" height="424"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </customView>
-                                <button verticalHuggingPriority="750" id="MQE-ts-iIn">
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MQE-ts-iIn">
                                     <rect key="frame" x="8" y="5" width="100" height="32"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="mX3-eO-IXN">
@@ -82,7 +82,7 @@ Gw
                                         <action selector="cancel:" target="-2" id="bab-Tm-5kX"/>
                                     </connections>
                                 </button>
-                                <button verticalHuggingPriority="750" id="3PR-J1-aKE">
+                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3PR-J1-aKE">
                                     <rect key="frame" x="180" y="5" width="112" height="32"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                     <buttonCell key="cell" type="push" title="Continue…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Ibk-mz-3rz">
@@ -98,11 +98,11 @@ DQ
                                 </button>
                             </subviews>
                         </customView>
-                        <customView id="uU2-RL-XAi">
+                        <customView fixedFrame="YES" id="uU2-RL-XAi">
                             <rect key="frame" x="301" y="0.0" width="699" height="470"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
-                                <customView id="hwM-6S-E69">
+                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hwM-6S-E69">
                                     <rect key="frame" x="0.0" y="0.0" width="699" height="470"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </customView>
@@ -123,12 +123,13 @@ DQ
                     </userDefinedRuntimeAttributes>
                 </splitView>
             </subviews>
+            <point key="canvasLocation" x="139" y="154"/>
         </view>
         <customView id="RtD-0g-Q5a" userLabel="Message View">
             <rect key="frame" x="0.0" y="0.0" width="590" height="273"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="pPL-IW-FD6">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pPL-IW-FD6">
                     <rect key="frame" x="18" y="241" width="248" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Updated commit message:" id="H9b-Gu-kkA">
@@ -137,7 +138,7 @@ DQ
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="DIo-C0-hvl">
+                <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DIo-C0-hvl">
                     <rect key="frame" x="20" y="83" width="550" height="150"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" drawsBackground="NO" id="PV2-zJ-Th2">
@@ -155,7 +156,7 @@ DQ
                                     <fragment content="&lt;MESSAGE&gt;">
                                         <attributes>
                                             <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                            <font key="NSFont" metaFont="toolTip"/>
+                                            <font key="NSFont" metaFont="controlContent" size="11"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural"/>
                                         </attributes>
                                     </fragment>
@@ -176,7 +177,7 @@ DQ
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="uTH-et-agS">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uTH-et-agS">
                     <rect key="frame" x="18" y="61" width="554" height="14"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="&lt;INFO&gt;" id="RGN-xW-ZIT">
@@ -185,7 +186,7 @@ DQ
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" id="jiN-49-CJi">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jiN-49-CJi">
                     <rect key="frame" x="434" y="13" width="142" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Rewrite Commit" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="JGJ-zD-wfi">
@@ -194,13 +195,13 @@ DQ
                         <string key="keyEquivalent" base64-UTF8="YES">
 DQ
 </string>
-                        <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+                        <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                     </buttonCell>
                     <connections>
                         <action selector="finishModalView:" target="-2" id="KB3-Kv-Pfn"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" id="2mu-cU-csS">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2mu-cU-csS">
                     <rect key="frame" x="334" y="13" width="100" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="GL2-s4-e19">

--- a/GitUpKit/Views/Base.lproj/GICommitSplitterViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GICommitSplitterViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -157,7 +157,7 @@ Gw
                                         <string key="keyEquivalent" base64-UTF8="YES">
 DQ
 </string>
-                                        <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+                                        <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                     </buttonCell>
                                     <connections>
                                         <action selector="continue:" target="-2" id="b6D-BI-9Ig"/>
@@ -294,7 +294,7 @@ DQ
                         <string key="keyEquivalent" base64-UTF8="YES">
 DQ
 </string>
-                        <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+                        <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                     </buttonCell>
                     <connections>
                         <action selector="finishModalView:" target="-2" id="vTp-E1-o2W"/>

--- a/GitUpKit/Views/Base.lproj/GIMapViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GIMapViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -32,18 +32,18 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <view translatesAutoresizingMaskIntoConstraints="NO" id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
+        <view id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
             <rect key="frame" x="0.0" y="0.0" width="700" height="467"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" horizontalScrollElasticity="none" id="NEk-yz-xrB" userLabel="Scroll View - Graph View">
+                <scrollView fixedFrame="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="NEk-yz-xrB" userLabel="Scroll View - Graph View">
                     <rect key="frame" x="0.0" y="0.0" width="700" height="467"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <clipView key="contentView" autoresizesSubviews="NO" id="MUH-N6-EF0">
                         <rect key="frame" x="0.0" y="0.0" width="700" height="467"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view autoresizesSubviews="NO" id="7uX-6u-ejZ" customClass="GIGraphView">
+                            <view autoresizesSubviews="NO" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7uX-6u-ejZ" customClass="GIGraphView">
                                 <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                             </view>
@@ -222,7 +222,7 @@ CA
             <rect key="frame" x="0.0" y="0.0" width="433" height="207"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" id="REx-8D-wmk">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="REx-8D-wmk">
                     <rect key="frame" x="133" y="165" width="280" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" usesSingleLineMode="YES" id="vz0-21-YpX">
@@ -234,7 +234,7 @@ CA
                         <outlet property="delegate" destination="-2" id="lRe-Bp-6pj"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="4yU-fk-jQd">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4yU-fk-jQd">
                     <rect key="frame" x="18" y="167" width="109" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="New tag name:" id="z3m-U3-57a">
@@ -243,7 +243,7 @@ CA
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="OiB-oe-wIs">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OiB-oe-wIs">
                     <rect key="frame" x="18" y="140" width="109" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Message:" id="MhN-Wm-sdU">
@@ -252,12 +252,12 @@ CA
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="31a-qF-7cr">
+                <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="31a-qF-7cr">
                     <rect key="frame" x="133" y="97" width="280" height="60"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" drawsBackground="NO" id="K5e-oW-uzS">
                         <rect key="frame" x="1" y="1" width="278" height="58"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" allowsUndo="YES" smartInsertDelete="YES" id="l0i-wG-st7" customClass="GICommitMessageView">
                                 <rect key="frame" x="0.0" y="75" width="293" height="58"/>
@@ -291,7 +291,7 @@ CA
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" id="Nob-wT-MZi">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nob-wT-MZi">
                     <rect key="frame" x="131" y="61" width="284" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Provide an optional message to create an annotated tag instead of a lightweight tag." id="5f2-fj-Z0Q">
@@ -300,7 +300,7 @@ CA
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" id="d34-tu-v8h">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d34-tu-v8h">
                     <rect key="frame" x="327" y="13" width="92" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Create" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="wP6-iD-CUg">
@@ -314,7 +314,7 @@ DQ
                         <action selector="finishModalView:" target="-2" id="9ml-Ih-wNC"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" id="w29-nc-RbK">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="w29-nc-RbK">
                     <rect key="frame" x="233" y="13" width="92" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="l8x-Ez-Uuz">
@@ -335,7 +335,7 @@ Gw
             <rect key="frame" x="0.0" y="0.0" width="384" height="101"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" id="fnf-HO-J16">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fnf-HO-J16">
                     <rect key="frame" x="124" y="59" width="240" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" usesSingleLineMode="YES" id="tS2-TD-tB5">
@@ -347,7 +347,7 @@ Gw
                         <outlet property="delegate" destination="-2" id="xkW-S8-IhJ"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="m4G-QU-XMh">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="m4G-QU-XMh">
                     <rect key="frame" x="18" y="61" width="100" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Branch name:" id="fiz-vE-xUY">
@@ -356,7 +356,7 @@ Gw
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" id="Lci-ng-5xc">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lci-ng-5xc">
                     <rect key="frame" x="278" y="13" width="92" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Rename" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="avr-T7-1eE">
@@ -370,7 +370,7 @@ DQ
                         <action selector="finishModalView:" target="-2" id="XO9-Id-evY"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" id="dMe-As-8cY">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dMe-As-8cY">
                     <rect key="frame" x="184" y="13" width="92" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="r4C-qF-UmE">
@@ -391,7 +391,7 @@ Gw
             <rect key="frame" x="0.0" y="0.0" width="360" height="101"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" id="0A5-t1-c3Z">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0A5-t1-c3Z">
                     <rect key="frame" x="100" y="59" width="240" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" usesSingleLineMode="YES" id="hOm-T2-MUD">
@@ -403,7 +403,7 @@ Gw
                         <outlet property="delegate" destination="-2" id="J88-MG-Hwh"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="1eh-qK-EgU">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1eh-qK-EgU">
                     <rect key="frame" x="18" y="61" width="76" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Tag name:" id="xvR-0J-9Ji">
@@ -412,7 +412,7 @@ Gw
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" id="jvz-rp-toI">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jvz-rp-toI">
                     <rect key="frame" x="254" y="13" width="92" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Rename" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="iKU-RW-3rW">
@@ -426,7 +426,7 @@ DQ
                         <action selector="finishModalView:" target="-2" id="VlL-77-AMm"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" id="2JE-Xl-GmX">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2JE-Xl-GmX">
                     <rect key="frame" x="160" y="13" width="92" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="itp-cr-xr4">
@@ -447,12 +447,12 @@ Gw
             <rect key="frame" x="0.0" y="0.0" width="590" height="251"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <scrollView autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="MtR-30-oY5">
+                <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MtR-30-oY5">
                     <rect key="frame" x="20" y="61" width="550" height="150"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" drawsBackground="NO" id="THQ-ht-MMy">
                         <rect key="frame" x="1" y="1" width="548" height="148"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" allowsUndo="YES" smartInsertDelete="YES" id="leL-YY-uqs" customClass="GICommitMessageView">
                                 <rect key="frame" x="0.0" y="0.0" width="548" height="148"/>
@@ -486,7 +486,7 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <button verticalHuggingPriority="750" id="ss3-Af-4aU">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ss3-Af-4aU">
                     <rect key="frame" x="454" y="13" width="122" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="&lt;BUTTON&gt;" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ciE-fC-og6">
@@ -495,13 +495,13 @@ Gw
                         <string key="keyEquivalent" base64-UTF8="YES">
 DQ
 </string>
-                        <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+                        <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                     </buttonCell>
                     <connections>
                         <action selector="finishModalView:" target="-2" id="DZ1-oQ-vNg"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Ukh-fa-YMw">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ukh-fa-YMw">
                     <rect key="frame" x="18" y="219" width="554" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="&lt;TITLE&gt;" id="pXD-VS-T9J">
@@ -510,7 +510,7 @@ DQ
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" id="ggo-NX-oiy">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ggo-NX-oiy">
                     <rect key="frame" x="360" y="13" width="92" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="o5d-4K-LgY">
@@ -531,7 +531,7 @@ Gw
             <rect key="frame" x="0.0" y="0.0" width="414" height="125"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" id="CUj-FC-ARp">
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CUj-FC-ARp">
                     <rect key="frame" x="154" y="83" width="240" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Required" drawsBackground="YES" usesSingleLineMode="YES" id="F18-8s-TZU">
@@ -543,7 +543,7 @@ Gw
                         <outlet property="delegate" destination="-2" id="l0X-Nx-z2N"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="5H0-9d-GEY">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5H0-9d-GEY">
                     <rect key="frame" x="18" y="85" width="130" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="New branch name:" id="pez-mo-54a">
@@ -552,7 +552,7 @@ Gw
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button id="W3U-R6-9yO">
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W3U-R6-9yO">
                     <rect key="frame" x="152" y="59" width="185" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Check Out Immediately" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="8fJ-Ia-klN">
@@ -560,7 +560,7 @@ Gw
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
-                <button verticalHuggingPriority="750" id="0Hb-Gb-gmN">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Hb-Gb-gmN">
                     <rect key="frame" x="308" y="13" width="92" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Create" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ZVK-Ou-HSU">
@@ -574,7 +574,7 @@ DQ
                         <action selector="finishModalView:" target="-2" id="kdW-6J-3j9"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" id="2Ox-ed-G2C">
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2Ox-ed-G2C">
                     <rect key="frame" x="214" y="13" width="92" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vjc-QU-xVm">

--- a/GitUpKit/Views/Base.lproj/GISimpleCommitViewController.xib
+++ b/GitUpKit/Views/Base.lproj/GISimpleCommitViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,37 +18,37 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <view translatesAutoresizingMaskIntoConstraints="NO" id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
+        <view id="Mge-gB-T5T" userLabel="Main View" customClass="GIView">
             <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <splitView dividerStyle="thin" vertical="YES" id="MrH-0U-K7B" customClass="GIDualSplitView">
+                <splitView fixedFrame="YES" dividerStyle="thin" vertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MrH-0U-K7B" customClass="GIDualSplitView">
                     <rect key="frame" x="0.0" y="0.0" width="1000" height="500"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>
-                        <customView id="aqx-CW-Hpb">
+                        <customView fixedFrame="YES" id="aqx-CW-Hpb">
                             <rect key="frame" x="0.0" y="0.0" width="300" height="500"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
-                                <splitView dividerStyle="thin" id="Xr2-bz-eaL" customClass="GIDualSplitView">
+                                <splitView fixedFrame="YES" dividerStyle="thin" translatesAutoresizingMaskIntoConstraints="NO" id="Xr2-bz-eaL" customClass="GIDualSplitView">
                                     <rect key="frame" x="0.0" y="0.0" width="300" height="500"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <customView id="5oI-c2-Y6H">
+                                        <customView fixedFrame="YES" id="5oI-c2-Y6H">
                                             <rect key="frame" x="0.0" y="0.0" width="300" height="285"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <customView id="OjA-hK-WAP">
+                                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OjA-hK-WAP">
                                                     <rect key="frame" x="0.0" y="0.0" width="300" height="285"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 </customView>
                                             </subviews>
                                         </customView>
-                                        <customView id="rFU-nO-Hjp">
+                                        <customView fixedFrame="YES" id="rFU-nO-Hjp">
                                             <rect key="frame" x="0.0" y="286" width="300" height="214"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" id="H0U-9x-3Cl">
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="H0U-9x-3Cl">
                                                     <rect key="frame" x="12" y="176" width="276" height="28"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                     <textFieldCell key="cell" controlSize="small" truncatesLastVisibleLine="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" id="dbO-mu-br6">
@@ -59,7 +59,7 @@
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <scrollView focusRingType="exterior" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="od0-zP-yaf">
+                                                <scrollView focusRingType="exterior" fixedFrame="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="od0-zP-yaf">
                                                     <rect key="frame" x="14" y="45" width="272" height="123"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <clipView key="contentView" drawsBackground="NO" id="3v3-B4-edQ">
@@ -77,7 +77,7 @@
                                                                     <fragment content="&lt;MESSAGE&gt;">
                                                                         <attributes>
                                                                             <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                            <font key="NSFont" metaFont="toolTip"/>
+                                                                            <font key="NSFont" metaFont="controlContent" size="11"/>
                                                                             <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural"/>
                                                                         </attributes>
                                                                     </fragment>
@@ -94,11 +94,11 @@
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
                                                     <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="ya4-9F-ykc">
-                                                        <rect key="frame" x="259" y="1" width="16" height="121"/>
+                                                        <rect key="frame" x="255" y="1" width="16" height="121"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
                                                 </scrollView>
-                                                <button verticalHuggingPriority="750" id="3PR-J1-aKE">
+                                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3PR-J1-aKE">
                                                     <rect key="frame" x="110" y="5" width="182" height="32"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                     <buttonCell key="cell" type="push" title="Commit All Changes" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Ibk-mz-3rz">
@@ -107,7 +107,7 @@
                                                         <string key="keyEquivalent" base64-UTF8="YES">
 DQ
 </string>
-                                                        <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+                                                        <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                                     </buttonCell>
                                                     <connections>
                                                         <action selector="commit:" target="-2" id="EeG-y7-Nd8"/>
@@ -131,11 +131,11 @@ DQ
                                 </splitView>
                             </subviews>
                         </customView>
-                        <customView id="dBG-Wf-83t">
+                        <customView fixedFrame="YES" id="dBG-Wf-83t">
                             <rect key="frame" x="301" y="0.0" width="699" height="500"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
-                                <customView id="hwM-6S-E69">
+                                <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hwM-6S-E69">
                                     <rect key="frame" x="0.0" y="0.0" width="699" height="500"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </customView>
@@ -156,6 +156,7 @@ DQ
                     </userDefinedRuntimeAttributes>
                 </splitView>
             </subviews>
+            <point key="canvasLocation" x="139" y="154"/>
         </view>
     </objects>
 </document>


### PR DESCRIPTION
Usage of a cmd+return is more common in modern macOS apps, so it makes sense to update option usage to a more familiar key binding.